### PR TITLE
MapLibre GL JS ドキュメントへのリンクを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ myCity.on("load", () => {
 
 ## カスタマイズする
 
-高松市スマートマップは、Maplibre, Geolonia Maps と互換性があります。詳しいカスタマイズの方法は、[API Reference \| MapLibre GL JS Docs \| MapLibre](https://maplibre.org/maplibre-gl-js-docs/api/) を参照してください。
+高松市スマートマップは、Maplibre, Geolonia Maps と互換性があります。詳しいカスタマイズの方法は、[Intro - MapLibre GL JS](https://maplibre.org/maplibre-gl-js/docs/API/) を参照してください。
 
 ## 独自ドメインでホスティングする
 


### PR DESCRIPTION
以前のリンク https://maplibre.org/maplibre-gl-js-docs/api/ がリンク切れになっていたので修正。